### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -24,7 +24,7 @@ setRotation	KEYWORD2
 setRotation	KEYWORD2
 height	KEYWORD2
 width	KEYWORD2
-invertDisplay KEYWORD2
-drawImage KEYWORD2
-setScrollArea  KEYWORD2
+invertDisplay	KEYWORD2
+drawImage	KEYWORD2
+setScrollArea	KEYWORD2
 scroll	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords