### PR TITLE
Change boolean to bool

### DIFF
--- a/ILI9488.cpp
+++ b/ILI9488.cpp
@@ -583,7 +583,7 @@ void ILI9488::pushColor(uint16_t color) {
   if (hwSPI) spi_end();
 }
 
-void ILI9488::pushColors(uint16_t *data, uint8_t len, boolean first) {
+void ILI9488::pushColors(uint16_t *data, uint8_t len, bool first) {
   uint16_t color;
   uint8_t  buff[len*3+1];
   uint16_t count = 0;
@@ -860,7 +860,7 @@ void ILI9488::setRotation(uint8_t m) {
 }
 
 
-void ILI9488::invertDisplay(boolean i) {
+void ILI9488::invertDisplay(bool i) {
   if (hwSPI) spi_begin();
   writecommand(i ? ILI9488_INVON : ILI9488_INVOFF);
   if (hwSPI) spi_end();

--- a/ILI9488.h
+++ b/ILI9488.h
@@ -132,7 +132,7 @@ class ILI9488 : public Adafruit_GFX {
            setScrollArea(uint16_t topFixedArea, uint16_t bottomFixedArea),
            scroll(uint16_t pixels),
            pushColor(uint16_t color),
-           pushColors(uint16_t *data, uint8_t len, boolean first),
+           pushColors(uint16_t *data, uint8_t len, bool first),
            drawImage(const uint8_t* img, uint16_t x, uint16_t y, uint16_t w, uint16_t h),
            fillScreen(uint16_t color),
            drawPixel(int16_t x, int16_t y, uint16_t color),
@@ -141,7 +141,7 @@ class ILI9488 : public Adafruit_GFX {
            fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
              uint16_t color),
            setRotation(uint8_t r),
-           invertDisplay(boolean i);
+           invertDisplay(bool i);
   uint16_t color565(uint8_t r, uint8_t g, uint8_t b);
 
   /* These are not for current use, 8-bit protocol only! */
@@ -165,7 +165,7 @@ class ILI9488 : public Adafruit_GFX {
 
 
 
-  boolean  hwSPI;
+  bool  hwSPI;
 
 #if defined (__AVR__) || defined(TEENSYDUINO)
   uint8_t mySPCR;


### PR DESCRIPTION
This fixes compiler warnings such as:

```
In file included from /home/ed/git/dryer-arduino/ui/src/graphicstest.ino:19:
.pio/libdeps/nucleo_f446re/ILI9488_ID4667/ILI9488.h:135:65: warning: 'boolean' is deprecated [-Wdeprecated-declarations]
  135 |            pushColors(uint16_t *data, uint8_t len, boolean first),
      |                                                                 ^
In file included from /home/ed/.platformio/packages/framework-arduinoststm32/cores/arduino/wiring.h:34,
                 from /home/ed/.platformio/packages/framework-arduinoststm32/cores/arduino/Arduino.h:32,
                 from /tmp/tmpjox95xz9:1:
/home/ed/.platformio/packages/framework-arduinoststm32/cores/arduino/wiring_constants.h:110:14: note: declared here
```